### PR TITLE
chore(config): derive version from package.json

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Read version from package.json
+const packageJsonPath = join(__dirname, '../../package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
 const configSchema = z.object({
   version: z.string(),
@@ -16,7 +22,7 @@ export type Config = z.infer<typeof configSchema>;
 
 function loadConfig(): Config {
   return {
-    version: '0.3.0',
+    version: packageJson.version,
     niktoBinary: process.env['NIKTO_BINARY'] ?? 'nikto',
     niktoMode: (process.env['NIKTO_MODE'] as Config['niktoMode']) ?? 'local',
     dockerImage: process.env['NIKTO_DOCKER_IMAGE'] ?? 'ghcr.io/sullo/nikto:latest',

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,9 +1,12 @@
 import { config } from '../src/config/index';
 
+// Read package.json to get the expected version
+const packageJson = require('../package.json');
+
 describe('Configuration', () => {
   it('should load default configuration', () => {
     expect(config).toBeDefined();
-    expect(config.version).toBe('0.3.0');
+    expect(config.version).toBe(packageJson.version);
     expect(config.niktoBinary).toBeDefined();
     expect(config.maxConcurrentScans).toBeGreaterThan(0);
     expect(config.defaultTimeout).toBeGreaterThan(0);


### PR DESCRIPTION
Fixes version synchronization issues between package.json, config, and tests.

## Problem
- Config had hard-coded version string that needed manual updates
- Tests expected specific version strings that broke on version bumps
- This caused CI failures when git tags didn't match hard-coded versions

## Solution
- **Config**: Now reads version dynamically from package.json using fs.readFileSync
- **Tests**: Now compares config.version against package.json version instead of hard-coded string
- **CI Integration**: Works seamlessly with release workflow that updates package.json via `npm version`

## Benefits
- ✅ **No more manual version updates** in config files
- ✅ **Tests never break** on version bumps
- ✅ **Single source of truth**: package.json version
- ✅ **CI compatibility**: Works with release workflow that syncs git tag → package.json

## Changes
- `src/config/index.ts`: Import and use package.json version
- `tests/config.test.ts`: Dynamic version assertion using package.json

## Testing
- ✅ All 32 tests passing
- ✅ TypeScript compilation successful
- ✅ Version correctly read from package.json (0.3.0)