### PR TITLE
🚀 Release v0.7.1: MCP SDK Migration to v1.17.1

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -29,7 +29,7 @@
   - Fixed: Skips npm prepare script during production build (--ignore-scripts)
   - Fixed: Copies correct file (index.cjs) instead of index.js
   - Result: Docker build now succeeds and creates functional nikto-mcp:latest image
-- **COMPLETE**: Command Line Help Fix - Hanging --help Issue Resolution (v0.4.0+)
+- **COMPLETE**: Command Line Help Fix - Hanging --help Issue Resolution (v0.7.0)
   - Fixed: npx nikto-mcp@latest --help command was hanging indefinitely
   - Root Cause: Application was starting MCP server without checking command-line arguments
   - Solution: Added argument parsing before server initialization
@@ -37,6 +37,13 @@
   - Result: --help displays comprehensive usage information and exits cleanly
   - Result: --version displays version information and exits cleanly
   - Verified: All 39 tests still passing after changes
+- **COMPLETE**: MCP SDK Migration - Tools List Discovery Fix (v0.7.0)
+  - Fixed: echo '{"id": "1", "method": "tools/list", "params": {}}' returning no tools
+  - Root Cause: Old MCP SDK API was deprecated, tools not properly registered
+  - Solution: Migrated to latest @modelcontextprotocol/sdk v1.17.1 with new McpServer API
+  - Implementation: Used server.registerTool() with zod schemas for proper tool registration
+  - Result: tools/list now correctly returns all 3 tools (scan, scan_status, stop_scan)
+  - Verified: JSON-RPC response includes proper tool schemas and descriptions
 - **COMPLETE**: TypeScript MCP Client Examples Implementation (February 8, 2025)
   - Created: `examples/` folder with comprehensive MCP client examples
   - Added: `examples/mcp-client.ts` - TypeScript MCP client using official SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
       "version": "0.4.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.15.1",
+        "@modelcontextprotocol/sdk": "^1.17.1",
         "tslib": "^2.8.1",
         "winston": "^3.17.0",
-        "zod": "^4.0.5"
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "nikto-mcp": "index.cjs"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -28,10 +31,10 @@
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.0",
         "tsx": "^4.20.3",
-        "typescript": "5.8.3"
+        "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1858,9 +1861,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.15.1.tgz",
-      "integrity": "sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.1.tgz",
+      "integrity": "sha512-CPle1OQehbWqd25La9Ack5B07StKIxh4+Bf19qnpZKJC1oI22Y0czZHbifjw1UoczIfKBwBDAp/dFxvHG13B5A==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -1878,15 +1881,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
@@ -7708,9 +7702,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   },
   "homepage": "https://github.com/weldpua2008/nikto-mcp#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.15.1",
+    "@modelcontextprotocol/sdk": "^1.17.1",
     "tslib": "^2.8.1",
     "winston": "^3.17.0",
-    "zod": "^4.0.5"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
@@ -58,7 +58,7 @@
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.0",
     "tsx": "^4.20.3",
-    "typescript": "5.8.3"
+    "typescript": "^5.8.3"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Major SDK migration from v1.15.1 to v1.17.1 resolving tools list discovery issue.

## Problem Solved
- tools/list method was returning no tools due to deprecated SDK API
- Migrated to modern McpServer API with proper tool registration

## Changes
- Upgraded @modelcontextprotocol/sdk to v1.17.1  
- Updated zod to v3.24.1 for compatibility
- Replaced manual request handlers with registerTool() methods
- Simplified code architecture with 77 lines removed

## Verification
- All 3 tools now properly discoverable via tools/list
- JSON schemas automatically generated from zod definitions
- TypeScript compilation successful
- Backward compatibility maintained

Ready for v0.7.1 release after merge.